### PR TITLE
fix: HackMD ドキュメントのタイトルを正しく設定

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -241,7 +241,10 @@ async def post_create_hackmd():
         if template_content is None:
             template_content = ''  # テンプレート取得失敗時は空文字
 
-        hackmd_url = create_hackmd_note(title, alias, template_content)
+        # タイトルを content の先頭に追加（HackMD はドキュメント内の # 見出しをタイトルとして表示）
+        content_with_title = f'# {title}\n\n{template_content}'
+
+        hackmd_url = create_hackmd_note(title, alias, content_with_title)
 
         # データ保存
         if hackmd_url:


### PR DESCRIPTION
## Summary
- HackMD で作成されるドキュメントのタイトルが「Untitled」になる問題を修正
- content の先頭に `# テックブログ一気読み選手権 yyyyMMdd 杯` を追加

## 変更内容
HackMD では API の `title` パラメータではなく、ドキュメント内の最初の `# 見出し` がタイトルとして表示されるため、content の先頭にタイトルを追加するよう修正しました。

## Test plan
- [ ] 19:00 の HackMD 自動作成で、正しいタイトルが設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)