### PR TITLE
fix: save_data のデータストア整合性とデータクリアの堅牢性を修正

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -98,30 +98,25 @@ def load_data():
     return {'hackmd': None, 'connpass': None}
 
 def save_data(data):
-    """Google Sheetsまたはローカルファイルにデータを保存"""
+    """Google Sheetsとローカルファイルの両方にデータを保存"""
+    # ローカルファイルに常に保存（フォールバック時の整合性を保証）
+    os.makedirs(os.path.dirname(DATA_FILE) if os.path.dirname(DATA_FILE) else '.', exist_ok=True)
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
     try:
         worksheet = get_worksheet()
         if worksheet:
-            # 既存データをクリア
             worksheet.clear()
-            
-            # ヘッダーを設定
             worksheet.update('A1:B1', [['キー', '値']])
-            
-            # データを書き込み
             rows = [[key, value if value else ''] for key, value in data.items()]
             if rows:
                 worksheet.update(f'A2:B{len(rows)+1}', rows)
-            
             print(f'Google Sheetsにデータを保存しました: {data}')
             return
     except Exception as e:
         print(f'Google Sheetsへのデータ保存エラー: {e}')
-    
-    # Google Sheets未設定またはエラー時はローカルファイルを使用
-    os.makedirs(os.path.dirname(DATA_FILE) if os.path.dirname(DATA_FILE) else '.', exist_ok=True)
-    with open(DATA_FILE, 'w', encoding='utf-8') as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
+
     print(f'ローカルファイルにデータを保存しました: {data}')
 
 def get_next_monday():
@@ -205,13 +200,16 @@ https://yamadashy.github.io/tech-blog-rss-feed/
 https://hatena.blog/dev
 https://techplay.jp/blog"""
 
-        await channel.send(message)
-        
-        # 投稿後にデータを削除（19:00の新規作成のため）
-        data['hackmd'] = None
-        data['connpass'] = None
-        save_data(data)
-        print('18:30投稿後にデータを削除しました')
+        try:
+            await channel.send(message)
+        except Exception as e:
+            print(f'18:30 投稿エラー: {e}')
+        finally:
+            # 投稿の成否に関わらずデータを削除（19:00の新規作成のため）
+            data['hackmd'] = None
+            data['connpass'] = None
+            save_data(data)
+            print('18:30投稿後にデータを削除しました')
 
 async def post_writing_time():
     """月曜 18:38 (JST) の投稿"""

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -525,3 +525,90 @@ async def test_check_and_post_connpass_no_hackmd():
     # connpass URL は保存されるが、投稿は行われない
     mock_save.assert_called_once()
     mock_channel.send.assert_not_called()
+
+
+# ========================================
+# データストア整合性のテスト
+# ========================================
+
+def test_save_data_always_writes_local_file():
+    """Google Sheets 保存成功時もローカルファイルに書き込むことを確認"""
+    test_data = {'hackmd': None, 'connpass': None}
+
+    mock_worksheet = MagicMock()
+    m = mock_open()
+
+    with patch('bot.get_worksheet', return_value=mock_worksheet):
+        with patch('builtins.open', m):
+            bot.save_data(test_data)
+
+    # Google Sheets にも保存される
+    mock_worksheet.clear.assert_called_once()
+    # ローカルファイルにも書き込まれる
+    m.assert_called_once_with('data.json', 'w', encoding='utf-8')
+
+
+def test_save_data_local_file_has_cleared_data_after_google_sheets_save():
+    """Google Sheets 保存後にローカルファイルにクリア済みデータが書き込まれることを確認"""
+    test_data = {'hackmd': None, 'connpass': None}
+
+    mock_worksheet = MagicMock()
+    m = mock_open()
+
+    with patch('bot.get_worksheet', return_value=mock_worksheet):
+        with patch('builtins.open', m):
+            bot.save_data(test_data)
+
+    # ローカルファイルに書き込まれたデータを検証
+    handle = m()
+    written_data = ''.join(call.args[0] for call in handle.write.call_args_list)
+    saved = json.loads(written_data)
+    assert saved['hackmd'] is None
+    assert saved['connpass'] is None
+
+
+# ========================================
+# post_start データクリアの堅牢性テスト
+# ========================================
+
+@pytest.mark.asyncio
+async def test_post_start_clears_data_after_send():
+    """18:30 投稿後にデータがクリアされることを確認"""
+    mock_channel = AsyncMock()
+    test_data = {
+        'hackmd': 'https://hackmd.io/test',
+        'connpass': 'https://connpass.com/test'
+    }
+
+    with patch.object(bot.bot, 'get_channel', return_value=mock_channel):
+        with patch('bot.load_data', return_value=test_data):
+            with patch('bot.save_data') as mock_save:
+                await bot.post_start()
+
+    # save_data が呼ばれ、両方のURLがNoneになっていることを確認
+    mock_save.assert_called_once()
+    saved_data = mock_save.call_args[0][0]
+    assert saved_data['hackmd'] is None
+    assert saved_data['connpass'] is None
+
+
+@pytest.mark.asyncio
+async def test_post_start_clears_data_even_if_send_fails():
+    """channel.send が失敗してもデータがクリアされることを確認"""
+    mock_channel = AsyncMock()
+    mock_channel.send.side_effect = Exception('Discord API error')
+    test_data = {
+        'hackmd': 'https://hackmd.io/test',
+        'connpass': 'https://connpass.com/test'
+    }
+
+    with patch.object(bot.bot, 'get_channel', return_value=mock_channel):
+        with patch('bot.load_data', return_value=test_data):
+            with patch('bot.save_data') as mock_save:
+                await bot.post_start()
+
+    # send が失敗しても save_data が呼ばれ、データがクリアされることを確認
+    mock_save.assert_called_once()
+    saved_data = mock_save.call_args[0][0]
+    assert saved_data['hackmd'] is None
+    assert saved_data['connpass'] is None


### PR DESCRIPTION
- save_data: Google Sheets 保存成功時もローカルファイルに常に書き込むよう変更 Google Sheets 読み込み失敗時のフォールバックで古いデータが返る問題を解消
- post_start: try/finally で channel.send 失敗時もデータクリアを保証

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented local data backup alongside existing cloud storage for enhanced data persistence

* **Bug Fixes**
  * Enhanced data cleanup reliability to ensure proper execution even when posting operations encounter errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->